### PR TITLE
Add Supabase infra, Edge Function API, and GitHub Actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
-# Backend
+# Backend (legacy Go API)
 SERVER_ADDRESS=:8080
 ALLOWED_ORIGINS=http://localhost:5173
 
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
 FIRECRAWL_API_KEY=
 
 # Frontend
-VITE_API_BASE=http://localhost:8080
+VITE_API_BASE=https://your-project-ref.supabase.co/functions/v1/api

--- a/.github/workflows/supabase-functions.yml
+++ b/.github/workflows/supabase-functions.yml
@@ -1,0 +1,40 @@
+name: Supabase Functions Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - supabase/functions/**
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+      ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Set function secrets
+        run: |
+          supabase secrets set \
+            SUPABASE_URL="$SUPABASE_URL" \
+            SUPABASE_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY" \
+            FIRECRAWL_API_KEY="$FIRECRAWL_API_KEY" \
+            ALLOWED_ORIGINS="$ALLOWED_ORIGINS"
+
+      - name: Deploy edge function
+        run: supabase functions deploy api --project-ref "$SUPABASE_PROJECT_ID" --no-verify-jwt

--- a/.github/workflows/supabase-infra.yml
+++ b/.github/workflows/supabase-infra.yml
@@ -1,0 +1,30 @@
+name: Supabase Infra Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - supabase/migrations/**
+      - supabase/config.toml
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Apply migrations
+        run: supabase db push --db-url "postgresql://postgres:$SUPABASE_DB_PASSWORD@db.$SUPABASE_PROJECT_ID.supabase.co:5432/postgres"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,13 @@
+project_id = "your-project-ref"
+
+[api]
+port = 54321
+
+[db]
+port = 54322
+
+[studio]
+port = 54323
+
+[functions]
+port = 54324

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -1,0 +1,486 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
+
+type EventRecord = {
+  id?: string;
+  source_url: string;
+  title?: string | null;
+  description?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  location_name?: string | null;
+  address?: string | null;
+  website?: string | null;
+  tags?: string[];
+  approved?: boolean;
+  created_at?: string;
+};
+
+type PlaceRecord = {
+  id?: string;
+  source_url: string;
+  name?: string | null;
+  description?: string | null;
+  category?: string | null;
+  address?: string | null;
+  website?: string | null;
+  family_friendly?: boolean;
+  tags?: string[];
+  approved?: boolean;
+  created_at?: string;
+};
+
+type CrawlRequest = {
+  url?: string;
+  type?: "events" | "places";
+};
+
+type ApproveRequest = {
+  id?: string;
+};
+
+type UpdateEventRequest = {
+  id?: string;
+  title?: string | null;
+  description?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  location_name?: string | null;
+  address?: string | null;
+  website?: string | null;
+  tags?: string[] | null;
+  approved?: boolean | null;
+};
+
+type UpdatePlaceRequest = {
+  id?: string;
+  name?: string | null;
+  description?: string | null;
+  category?: string | null;
+  address?: string | null;
+  website?: string | null;
+  family_friendly?: boolean | null;
+  tags?: string[] | null;
+  approved?: boolean | null;
+};
+
+type FirecrawlResponse<T> = {
+  data?: T;
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const firecrawlApiKey = Deno.env.get("FIRECRAWL_API_KEY") ?? "";
+const allowedOrigins = (Deno.env.get("ALLOWED_ORIGINS") ?? "*")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+
+const baseHeaders = {
+  "Content-Type": "application/json",
+};
+
+const corsHeaders = (origin: string | null) => {
+  const allowedOrigin = resolveAllowedOrigin(origin);
+  return {
+    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Methods": "GET,POST,PATCH,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, apikey",
+    "Access-Control-Allow-Credentials": "true",
+  };
+};
+
+const resolveAllowedOrigin = (origin: string | null) => {
+  if (allowedOrigins.includes("*")) {
+    return "*";
+  }
+  if (!origin) {
+    return allowedOrigins[0] ?? "";
+  }
+  return allowedOrigins.includes(origin) ? origin : allowedOrigins[0] ?? "";
+};
+
+serve(async (req) => {
+  const origin = req.headers.get("Origin");
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: { ...baseHeaders, ...corsHeaders(origin) },
+    });
+  }
+
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    return jsonResponse(
+      { error: "missing Supabase configuration" },
+      500,
+      origin,
+    );
+  }
+
+  const url = new URL(req.url);
+  const path = url.pathname.replace(/^\/api/, "") || "/";
+
+  try {
+    if (path === "/crawl" && req.method === "POST") {
+      return await handleCrawl(req, origin);
+    }
+
+    if (path === "/events") {
+      if (req.method === "GET") {
+        return await handleList("events", true, origin);
+      }
+      if (req.method === "PATCH") {
+        return await handleUpdateEvent(req, origin);
+      }
+    }
+
+    if (path === "/places") {
+      if (req.method === "GET") {
+        return await handleList("places", true, origin);
+      }
+      if (req.method === "PATCH") {
+        return await handleUpdatePlace(req, origin);
+      }
+    }
+
+    if (path === "/admin/events" && req.method === "GET") {
+      return await handleList("events", false, origin);
+    }
+
+    if (path === "/admin/places" && req.method === "GET") {
+      return await handleList("places", false, origin);
+    }
+
+    if (path === "/events/approve" && req.method === "PATCH") {
+      return await handleApprove("events", req, origin);
+    }
+
+    if (path === "/places/approve" && req.method === "PATCH") {
+      return await handleApprove("places", req, origin);
+    }
+
+    return jsonResponse({ error: "not found" }, 404, origin);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unexpected error";
+    return jsonResponse({ error: message }, 500, origin);
+  }
+});
+
+async function handleCrawl(req: Request, origin: string | null) {
+  const body = await parseJSON<CrawlRequest>(req);
+  if (!body.url || (body.type !== "events" && body.type !== "places")) {
+    return jsonResponse({ error: "missing url or invalid type" }, 400, origin);
+  }
+
+  if (!firecrawlApiKey) {
+    return jsonResponse({ error: "missing FIRECRAWL_API_KEY" }, 400, origin);
+  }
+
+  if (body.type === "events") {
+    const response = await fetchFirecrawl<{ events: EventSchema[] }>({
+      url: body.url,
+      schema: firecrawlEventSchema,
+    });
+
+    const events = (response?.events ?? []).map((item) => ({
+      source_url: body.url,
+      title: item.title ?? null,
+      description: item.description ?? null,
+      start_time: parseTime(item.start_time),
+      end_time: parseTime(item.end_time),
+      location_name: item.location_name ?? null,
+      address: item.address ?? null,
+      website: item.website ?? null,
+      tags: item.tags ?? [],
+      approved: false,
+      created_at: new Date().toISOString(),
+    } satisfies EventRecord));
+
+    if (events.length === 0) {
+      return jsonResponse([], 200, origin);
+    }
+
+    const { error } = await supabase.from("events").insert(events);
+    if (error) {
+      return jsonResponse({ error: error.message }, 502, origin);
+    }
+
+    return jsonResponse(events, 200, origin);
+  }
+
+  const response = await fetchFirecrawl<{ places: PlaceSchema[] }>({
+    url: body.url,
+    schema: firecrawlPlaceSchema,
+  });
+
+  const places = (response?.places ?? []).map((item) => ({
+    source_url: body.url,
+    name: item.name ?? null,
+    description: item.description ?? null,
+    category: item.category ?? null,
+    address: item.address ?? null,
+    website: item.website ?? null,
+    family_friendly: item.family_friendly ?? false,
+    tags: item.tags ?? [],
+    approved: false,
+    created_at: new Date().toISOString(),
+  } satisfies PlaceRecord));
+
+  if (places.length === 0) {
+    return jsonResponse([], 200, origin);
+  }
+
+  const { error } = await supabase.from("places").insert(places);
+  if (error) {
+    return jsonResponse({ error: error.message }, 502, origin);
+  }
+
+  return jsonResponse(places, 200, origin);
+}
+
+async function handleList(
+  table: "events" | "places",
+  approved: boolean,
+  origin: string | null,
+) {
+  const { data, error } = await supabase
+    .from(table)
+    .select("*")
+    .eq("approved", approved)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return jsonResponse({ error: error.message }, 502, origin);
+  }
+
+  return jsonResponse(data ?? [], 200, origin);
+}
+
+async function handleApprove(
+  table: "events" | "places",
+  req: Request,
+  origin: string | null,
+) {
+  const body = await parseJSON<ApproveRequest>(req);
+  if (!body.id) {
+    return jsonResponse({ error: "missing id" }, 400, origin);
+  }
+
+  const { error } = await supabase
+    .from(table)
+    .update({ approved: true })
+    .eq("id", body.id);
+
+  if (error) {
+    return jsonResponse({ error: error.message }, 502, origin);
+  }
+
+  return jsonResponse({ status: "approved" }, 200, origin);
+}
+
+async function handleUpdateEvent(req: Request, origin: string | null) {
+  const body = await parseJSON<UpdateEventRequest>(req);
+  if (!body.id) {
+    return jsonResponse({ error: "missing id" }, 400, origin);
+  }
+
+  const updates: Record<string, unknown> = {};
+
+  if (body.title !== undefined) updates.title = body.title;
+  if (body.description !== undefined) updates.description = body.description;
+  if (body.start_time !== undefined) {
+    updates.start_time = body.start_time === "" || body.start_time === null
+      ? null
+      : parseTimeStrict(body.start_time);
+  }
+  if (body.end_time !== undefined) {
+    updates.end_time = body.end_time === "" || body.end_time === null
+      ? null
+      : parseTimeStrict(body.end_time);
+  }
+  if (body.location_name !== undefined) updates.location_name = body.location_name;
+  if (body.address !== undefined) updates.address = body.address;
+  if (body.website !== undefined) updates.website = body.website;
+  if (body.tags !== undefined) updates.tags = body.tags ?? [];
+  if (body.approved !== undefined) updates.approved = body.approved;
+
+  const { error } = await supabase
+    .from("events")
+    .update(updates)
+    .eq("id", body.id);
+
+  if (error) {
+    return jsonResponse({ error: error.message }, 502, origin);
+  }
+
+  return jsonResponse({ status: "updated" }, 200, origin);
+}
+
+async function handleUpdatePlace(req: Request, origin: string | null) {
+  const body = await parseJSON<UpdatePlaceRequest>(req);
+  if (!body.id) {
+    return jsonResponse({ error: "missing id" }, 400, origin);
+  }
+
+  const updates: Record<string, unknown> = {};
+
+  if (body.name !== undefined) updates.name = body.name;
+  if (body.description !== undefined) updates.description = body.description;
+  if (body.category !== undefined) updates.category = body.category;
+  if (body.address !== undefined) updates.address = body.address;
+  if (body.website !== undefined) updates.website = body.website;
+  if (body.family_friendly !== undefined) {
+    updates.family_friendly = body.family_friendly;
+  }
+  if (body.tags !== undefined) updates.tags = body.tags ?? [];
+  if (body.approved !== undefined) updates.approved = body.approved;
+
+  const { error } = await supabase
+    .from("places")
+    .update(updates)
+    .eq("id", body.id);
+
+  if (error) {
+    return jsonResponse({ error: error.message }, 502, origin);
+  }
+
+  return jsonResponse({ status: "updated" }, 200, origin);
+}
+
+async function parseJSON<T>(req: Request): Promise<T> {
+  try {
+    return await req.json();
+  } catch {
+    throw new Error("invalid request");
+  }
+}
+
+function jsonResponse(payload: unknown, status: number, origin: string | null) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...baseHeaders, ...corsHeaders(origin) },
+  });
+}
+
+function parseTime(value?: string | null): string | null {
+  if (!value) return null;
+
+  const parsed = Date.parse(value);
+  if (!Number.isNaN(parsed)) {
+    return new Date(parsed).toISOString();
+  }
+
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2})$/);
+  if (match) {
+    const date = new Date(`${match[1]}T${match[2]}:00Z`);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+
+  return null;
+}
+
+function parseTimeStrict(value?: string | null): string {
+  if (!value) return "";
+
+  const parsed = parseTime(value);
+  if (!parsed) {
+    throw new Error("invalid time format");
+  }
+  return parsed;
+}
+
+type EventSchema = {
+  title?: string;
+  description?: string;
+  start_time?: string;
+  end_time?: string;
+  location_name?: string;
+  address?: string;
+  website?: string;
+  tags?: string[];
+};
+
+type PlaceSchema = {
+  name?: string;
+  description?: string;
+  category?: string;
+  address?: string;
+  website?: string;
+  family_friendly?: boolean;
+  tags?: string[];
+};
+
+const firecrawlEventSchema = {
+  type: "object",
+  properties: {
+    events: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          description: { type: "string" },
+          start_time: { type: "string" },
+          end_time: { type: "string" },
+          location_name: { type: "string" },
+          address: { type: "string" },
+          website: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+  },
+} as const;
+
+const firecrawlPlaceSchema = {
+  type: "object",
+  properties: {
+    places: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          description: { type: "string" },
+          category: { type: "string" },
+          address: { type: "string" },
+          website: { type: "string" },
+          family_friendly: { type: "boolean" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+  },
+} as const;
+
+async function fetchFirecrawl<T>(payload: {
+  url: string;
+  schema: Record<string, unknown>;
+}): Promise<T | null> {
+  const response = await fetch("https://api.firecrawl.dev/v1/extract", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${firecrawlApiKey}`,
+    },
+    body: JSON.stringify({
+      url: payload.url,
+      schema: payload.schema,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("firecrawl request failed");
+  }
+
+  const data = (await response.json()) as FirecrawlResponse<T>;
+  if (!data.data) {
+    throw new Error("empty firecrawl response");
+  }
+
+  return data.data;
+}

--- a/supabase/migrations/0001_init.sql
+++ b/supabase/migrations/0001_init.sql
@@ -1,0 +1,34 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.events (
+  id uuid primary key default gen_random_uuid(),
+  source_url text not null,
+  title text,
+  description text,
+  start_time timestamptz,
+  end_time timestamptz,
+  location_name text,
+  address text,
+  website text,
+  tags text[] not null default '{}'::text[],
+  approved boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists events_approved_idx on public.events (approved);
+
+create table if not exists public.places (
+  id uuid primary key default gen_random_uuid(),
+  source_url text not null,
+  name text,
+  description text,
+  category text,
+  address text,
+  website text,
+  family_friendly boolean not null default false,
+  tags text[] not null default '{}'::text[],
+  approved boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists places_approved_idx on public.places (approved);


### PR DESCRIPTION
### Motivation
- Move the existing backend API to a hosted Supabase Edge Function and manage database schema as infrastructure-as-code. 
- Provide a single hosted API surface for crawl, listing, update, and approval operations backed by Supabase. 
- Make infra and function deployment repeatable by adding GitHub Actions workflows for migrations and functions. 
- Update environment configuration and frontend API base to point at the Supabase function endpoint.

### Description
- Add `supabase/migrations/0001_init.sql` to create `events` and `places` tables with indexes and `pgcrypto` extension. 
- Add a Supabase Edge Function at `supabase/functions/api/index.ts` implementing endpoints for `/api/crawl`, `/api/events`, `/api/places`, `/api/admin/*`, `/api/*/approve`, using the Supabase JS client and Firecrawl integration. 
- Add infra config `supabase/config.toml` and update `.env.example` to include `SUPABASE_SERVICE_ROLE_KEY` and set `VITE_API_BASE` to the functions URL. 
- Add GitHub Actions workflows ` .github/workflows/supabase-infra.yml` and ` .github/workflows/supabase-functions.yml` to push DB migrations and deploy the Edge Function, respectively.

### Testing
- No automated tests were executed for this change. 
- The new deploy workflows are configured to run on `push` to `main` for the relevant paths and via `workflow_dispatch`. 
- Manual local verification is possible by setting required env vars and running the Supabase local dev ports defined in `supabase/config.toml`. 
- The code compiles in the repository context and was committed; CI execution of the new workflows was not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695431b90138832ea50b980d720b4dfa)