### PR TITLE
Group stack details under 'Technical stack choices' in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Core Principles
+
+* Explicit is better than implicit and magic. Everything understandable by reading code/config.
+* Simple is better than complex
+* Optimize for ease of operation, reliable engineering
+* Fewer platforms/3rd party dependencies is better, simpler
+* Fast MVP
+
+# Technical stack choices
+
+## Operation
+
+### Code hosting
+
+* Github
+
+### CI/CD
+
+* Github actions
+
+## Frontend
+
+### Language
+
+* Typescript
+
+### Bundler / UI framework
+
+* Vite + React + TanStack Router
+
+### Styling / UI components
+
+* Tailwind + shadcn/ui
+
+### State/data fetching & Forms
+
+* Tanstack Query
+* Tanstack Form
+
+### Hosting
+
+* Github Pages
+
+## Backend
+
+### Language
+
+* Typescript (locked by Supabase Edge Function)
+
+### Auth
+
+* Supabase Auth
+
+### Server Hosting
+
+* Supabase Edge Function


### PR DESCRIPTION
### Motivation

- Provide a single, explicit reference of core engineering principles and platform/stack choices for the repository.
- Make operational defaults and frontend/backend stack choices discoverable and easy to inspect in `AGENTS.md`.
- Organize documentation to avoid ambiguity by grouping stack details under a clear `Technical stack choices` heading.

### Description

- Add `AGENTS.md` containing a `Core Principles` section that enumerates the project's engineering principles.
- Move operation, frontend, and backend entries under a new `Technical stack choices` heading for clearer structure.
- Document specific stack selections including `Typescript`, `Vite + React + TanStack Router`, `Tailwind + shadcn/ui`, `Tanstack Query`, `Supabase Auth`, and `Supabase Edge Function`.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955800dc658832e95033a8ce4a97fd0)