### PR TITLE
Add React Query provider and convert Supabase fetches to `useQuery`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",
     "@supabase/supabase-js": "^2.50.0",
+    "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-router": "^1.144.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 
 import { routeTree } from "./App";
 import "./index.css";
 
 const router = createRouter({ routeTree });
+const queryClient = new QueryClient();
 
 declare module "@tanstack/react-router" {
   interface Register {
@@ -15,6 +17,8 @@ declare module "@tanstack/react-router" {
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
### Motivation
- Introduce TanStack React Query to centralize and cache Supabase data fetching and reduce manual state management.
- Replace ad-hoc `useEffect` fetches and manual `setEvents`/`setPlaces`/`setPendingEvents`/`setPendingPlaces` updates with declarative queries to improve reactivity and simplify logic.
- Use query invalidation to refresh lists after crawl/save/approve mutations instead of custom refresh functions.

### Description
- Added dependency `@tanstack/react-query` to `frontend/package.json` and created a `QueryClient` in `frontend/src/main.tsx` wrapped with `QueryClientProvider`.
- Replaced public/admin Supabase fetch `useEffect` logic in `frontend/src/App.tsx` with `useQuery` hooks keyed by route/session state using `useQuery` and `useQueryClient`.
- Removed manual events/places/pending state variables and derived those lists from query results, while preserving draft state handling for pending items.
- Switched mutation flows (`handleCrawlSubmit`, `saveEvent`, `savePlace`, `approveEvent`, `approvePlace`) to call `queryClient.invalidateQueries` for appropriate query keys instead of calling refresh helper functions.

### Testing
- No automated tests were executed as part of this change.
- Files modified: `frontend/package.json`, `frontend/src/main.tsx`, and `frontend/src/App.tsx`.
- A commit was created containing the changes; no CI or lint steps were run during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695585426be4832eb1b11219336ae74d)