### PR TITLE
Migrate admin review flows to TanStack Form

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",
     "@supabase/supabase-js": "^2.50.0",
+    "@tanstack/react-form": "^0.47.0",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-router": "^1.144.0",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
### Motivation
- Replace ad-hoc local draft state and input handlers with a predictable form library for clearer controlled inputs and submission flow.
- Use TanStack Form to centralize form state and per-item submissions for admin review of crawled events and places.
- Convert admin sign-in to a form-driven flow to avoid scattered auth state.

### Description
- Added `@tanstack/react-form` to `frontend/package.json` and imported `useForm` in `frontend/src/App.tsx`.
- Replaced `eventDrafts`/`placeDrafts` local state and change handlers with per-item `EventReviewCard` and `PlaceReviewCard` components that use `useForm` and submit via `onSubmit` to `saveEvent`/`savePlace` (now accept a `draft` argument). 
- Migrated `AdminAuthPanel` to a TanStack Form with controlled `email`/`password` fields and changed `handleSignIn` to accept `(email, password)` parameters. 
- Updated `AppData` types and the `AdminRoute`/`RootLayout` wiring to remove the old draft and auth input state and wire the new form-driven handlers.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695592a6678c832ebba85af0c686df12)